### PR TITLE
Fix name of template var

### DIFF
--- a/template/runner-config.tpl
+++ b/template/runner-config.tpl
@@ -44,7 +44,7 @@ check_interval = 0
       "amazonec2-security-group=${runners_security_group_name}",
       "amazonec2-tags=${runners_tags}",
       "amazonec2-monitoring=${runners_monitoring}",
-      "amazonec2-iam-instance-profile=${runners_instance_profile}",
+      "amazonec2-iam-instance-profile=${runners_iam_instance_profile_name}",
       "amazonec2-root-size=${runners_root_size}"
       ${docker_machine_options}
     ]


### PR DESCRIPTION
I tried using your branch, but the name of the variable was not consistent with the terraform module. I fixed the name and it worked for me. 